### PR TITLE
Document Hedera endpoint coverage matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,30 +10,55 @@ Hadeda is an R package that aims to provide idiomatic tidyverse wrappers around 
 * **Dual transport support** – favor a single set of user-facing verbs that can transparently call either REST or gRPC transports, keeping the function names and arguments identical regardless of network protocol.
 * **Composable workflows** – functions will favor pure data transformations with minimal side effects, enabling chaining with `%>%` or `|>`.
 
-## Target service endpoints
+## Endpoint coverage summary
 
-The following table lists the initial set of Hedera network endpoints that Hadeda functions will cover. REST endpoints align with the Hedera Mirror Node API, while RPC endpoints use the Hedera gRPC services as defined in the protobuf specifications. Each verb is designed to dispatch to REST or gRPC implementations based on the capabilities of the configured client while sharing the same tidyverse-friendly signature.
+Phase 1, Step 1 in [`docs/landscape-analysis.md`](docs/landscape-analysis.md) documents
+the complete parity matrix between Hadeda functions, Hedera Mirror Node REST
+endpoints, and the gRPC RPCs surfaced by the official Go, Java, and JavaScript
+SDKs. The highlights are summarised below.
 
-| Domain | Endpoint | Method / RPC | Primary use | Planned function(s) |
-| --- | --- | --- | --- | --- |
-| Accounts | `/api/v1/accounts` | GET | List accounts with optional filtering | `accounts_list()` → REST; `accounts_list(mode = "grpc")` → gRPC mirror (future) |
-| Accounts | `/api/v1/accounts/{accountId}` | GET | Retrieve a single account | `accounts_get()` (REST/gRPC shared signature) |
-| Accounts | `/api/v1/accounts/{accountId}/balance` | GET | Fetch account balance | `accounts_balance()` (auto-select transport) |
-| Tokens | `/api/v1/tokens` | GET | List tokens with metadata | `tokens_list()` (REST first, gRPC when mirror available) |
-| Tokens | `/api/v1/tokens/{tokenId}` | GET | Retrieve token details | `tokens_get()` |
-| Transactions | `/api/v1/transactions` | GET | Query transactions with filters | `transactions_list()` |
-| Transactions | `/api/v1/transactions/{transactionId}` | GET | Get transaction record | `transactions_get()` |
-| Topics | `/api/v1/topics/{topicId}/messages` | GET | Read topic messages | `topics_messages()` (REST) |
-| Network | `/api/v1/network/nodes` | GET | List available network nodes | `network_nodes()` (REST) |
-| Smart Contracts | `/api/v1/contracts` | GET | List smart contracts | `contracts_list()` |
-| Smart Contracts | `/api/v1/contracts/{contractId}` | GET | Retrieve contract bytecode & metadata | `contracts_get()` |
-| Consensus | `ConsensusService/SubmitMessage` | gRPC | Submit HCS message | `consensus_submit_message()` (gRPC primary, REST fallback) |
-| Crypto | `CryptoService/CreateAccount` | gRPC | Create new account | `crypto_create_account()` |
-| Crypto | `CryptoService/TransferCrypto` | gRPC | Transfer hbars or tokens | `crypto_transfer()` |
-| SmartContract | `SmartContractService/CallContract` | gRPC | Execute smart contract function | `contract_call()` |
-| Token | `TokenService/CreateToken` | gRPC | Create fungible or NFT token | `token_create()` |
+### Mirror Node REST endpoints
 
-This set will expand as additional Hedera services and protobuf operations are incorporated.
+Hadeda will expose verbs for every Mirror Node endpoint that the reference SDKs
+wrap today, grouped by functional area:
+
+* **Accounts and balances** – `accounts_list()`, `accounts_get()`,
+  `accounts_balance()`, allowance readers, rewards history, and `balances_list()`
+  for timestamped snapshots.
+* **Blocks and contracts** – block pagination plus full contract metadata,
+  state, result listings, and per-transaction execution lookups.
+* **Network and governance** – exchange rates, fee schedules, node address
+  book, and supply metrics to match the Java SDK helper utilities.
+* **Tokens and NFTs** – token metadata, balances, NFT inventory and
+  transactions, and token-level allowance views.
+* **Topics and transactions** – transaction queries and state proofs alongside
+  topic message history and future streaming helpers.
+* **Schedules and proofs** – schedule listings, detail lookups, and
+  `/stateproofs/{transactionId}` to support regulatory workflows.
+
+### gRPC services
+
+Every RPC defined in the Hedera protobufs that is exposed by the Go, Java, and
+JavaScript SDKs has a corresponding Hadeda verb:
+
+* **CryptoService** – account lifecycle management, hbar/token transfers, and
+  allowance administration (`crypto_create_account()`, `crypto_transfer()`,
+  `crypto_delete_allowances()`, etc.).
+* **ConsensusService** – topic message submission (chunked and single) and
+  topic metadata queries.
+* **FileService** – file creation, updates, appends, deletes, and metadata
+  queries.
+* **SmartContractService** – contract deployment, updates, on-ledger and local
+  calls, deletions, and record retrieval.
+* **TokenService** – token lifecycle operations, treasury interactions,
+  association helpers, and NFT-specific queries.
+* **ScheduleService** – schedule creation, signing, deletion, and info queries.
+* **Network/Util/Freeze services** – network metadata, PRNG utility, and freeze
+  orchestration endpoints required for node operators.
+
+Additional streaming helpers such as `topics_messages_stream()` and
+`consensus_topic_subscribe()` will wrap the Mirror Node streaming APIs so that R
+workflows remain on par with JavaScript SDK capabilities.
 
 ## Naming and argument conventions
 

--- a/docs/landscape-analysis.md
+++ b/docs/landscape-analysis.md
@@ -1,0 +1,181 @@
+# Phase 1 – Step 1: Landscape analysis
+
+This document catalogs the Hedera Mirror Node REST endpoints and gRPC service RPCs
+covered by the official Go, Java, and JavaScript SDKs so that Hadeda can expose a
+functionally equivalent surface area. It will guide future implementation work and
+serve as the source of truth for endpoint-to-function mappings.
+
+All planned Hadeda verbs share the signature conventions described in the README.
+Each entry below references the upstream capability and the corresponding
+Hadeda function we will implement.
+
+## Mirror Node REST endpoints
+
+The Mirror Node API is documented at <https://docs.hedera.com/hedera/mirror-node-api>.
+The table below consolidates the endpoints actively supported by the SDKs and maps
+them to Hadeda functions. When a Mirror Node endpoint corresponds to a gRPC
+query, Hadeda will still provide an HTTP implementation because REST is the most
+widely available transport today.
+
+| Domain | Endpoint | Purpose | Planned Hadeda function |
+| --- | --- | --- | --- |
+| Accounts | `/api/v1/accounts` | List accounts with optional filtering, pagination, and staking metadata | `accounts_list()` |
+| Accounts | `/api/v1/accounts/{accountId}` | Retrieve a single account, including key, memo, staking info | `accounts_get()` |
+| Accounts | `/api/v1/accounts/{accountId}/balance` | Fetch the latest balance snapshot for an account | `accounts_balance()` |
+| Accounts | `/api/v1/accounts/{accountId}/allowances/crypto` | View approved HBAR allowances | `accounts_allowances_crypto()` |
+| Accounts | `/api/v1/accounts/{accountId}/allowances/tokens` | View approved fungible token allowances | `accounts_allowances_tokens()` |
+| Accounts | `/api/v1/accounts/{accountId}/allowances/nfts` | View approved NFT allowances | `accounts_allowances_nfts()` |
+| Accounts | `/api/v1/accounts/{accountId}/rewards` | Retrieve staking reward history | `accounts_rewards()` |
+| Accounts | `/api/v1/balances` | List account balances at a consensus timestamp | `balances_list()` |
+| Blocks | `/api/v1/blocks` | Enumerate blocks with hash, number, and timestamp | `blocks_list()` |
+| Blocks | `/api/v1/blocks/{blockNumberOrHash}` | Retrieve details for a specific block | `blocks_get()` |
+| Contracts | `/api/v1/contracts` | List smart contracts and metadata | `contracts_list()` |
+| Contracts | `/api/v1/contracts/{contractId}` | Fetch contract bytecode and attributes | `contracts_get()` |
+| Contracts | `/api/v1/contracts/{contractId}/results` | List execution results for a contract | `contracts_results()` |
+| Contracts | `/api/v1/contracts/results` | Query contract call results across contracts | `contracts_results_list()` |
+| Contracts | `/api/v1/contracts/results/{transactionId}` | Fetch a single contract execution result | `contracts_results_get()` |
+| Contracts | `/api/v1/contracts/{contractId}/state` | Get key-value state entries for a contract | `contracts_state()` |
+| Network | `/api/v1/network/exchangerate` | Retrieve current and next exchange rates | `network_exchange_rate()` |
+| Network | `/api/v1/network/fees` | Fetch fee schedules | `network_fees()` |
+| Network | `/api/v1/network/nodes` | List mirror and network nodes | `network_nodes()` |
+| Network | `/api/v1/network/supply` | Retrieve supply metrics (hbar total/circulating) | `network_supply()` |
+| Schedules | `/api/v1/schedules` | List scheduled transactions | `schedules_list()` |
+| Schedules | `/api/v1/schedules/{scheduleId}` | Get a scheduled transaction | `schedules_get()` |
+| State Proof | `/api/v1/stateproofs/{transactionId}` | Retrieve a transaction state proof | `stateproof_get()` |
+| Tokens | `/api/v1/tokens` | List tokens with filters | `tokens_list()` |
+| Tokens | `/api/v1/tokens/{tokenId}` | Retrieve token metadata | `tokens_get()` |
+| Tokens | `/api/v1/tokens/{tokenId}/balances` | List token balances by account | `tokens_balances()` |
+| Tokens | `/api/v1/tokens/{tokenId}/nfts` | Enumerate NFTs for a token | `tokens_nfts()` |
+| Tokens | `/api/v1/tokens/{tokenId}/nfts/{serialNumber}` | Fetch a single NFT | `tokens_nfts_get()` |
+| Tokens | `/api/v1/tokens/{tokenId}/nfts/{serialNumber}/transactions` | NFT transfer history | `tokens_nft_transactions()` |
+| Tokens | `/api/v1/tokens/{tokenId}/allowances` | Allowance list for a token | `tokens_allowances()` |
+| Topics | `/api/v1/topics/{topicId}/messages` | Stream topic messages | `topics_messages()` |
+| Transactions | `/api/v1/transactions` | List transactions with filters | `transactions_list()` |
+| Transactions | `/api/v1/transactions/{transactionId}` | Fetch transaction record and metadata | `transactions_get()` |
+| Transactions | `/api/v1/transactions/{transactionId}/stateproof` | Retrieve state proof for a transaction | `transactions_stateproof()` |
+| Transactions | `/api/v1/transactions/{transactionId}/record` | Retrieve detailed record | `transactions_record()` |
+
+Additional REST helpers planned for parity with official SDK utilities:
+
+* `network_address_book()` – combine `/network/nodes` and key data for operator setup.
+* `accounts_relationships()` – flatten token relationship list columns like the Java
+  SDK helper utilities.
+* `topics_messages_stream()` – wrap the Mirror Node SSE/WebSocket endpoints once
+  available so R users can subscribe to live topics similar to JavaScript SDKs.
+
+## gRPC service coverage
+
+The official SDKs expose the Hedera gRPC services defined in
+`hedera-protobufs`. Hadeda will mirror these operations with tidyverse-friendly
+functions. Each RPC below will correspond to a Hadeda verb accepting a `.client`
+configured with signing keys and channel information.
+
+### Crypto Service (`CryptoService`)
+
+| RPC | Description | Planned Hadeda function |
+| --- | --- | --- |
+| `createAccount` | Create an account | `crypto_create_account()` |
+| `updateAccount` | Update mutable account properties | `crypto_update_account()` |
+| `cryptoTransfer` | Transfer hbar or tokens between accounts | `crypto_transfer()` |
+| `cryptoDelete` | Delete an account and transfer remaining balance | `crypto_delete()` |
+| `approveAllowances` | Approve fungible/NFT allowances | `crypto_approve_allowances()` |
+| `deleteAllowances` | Revoke allowances | `crypto_delete_allowances()` |
+| `getAccountRecords` | Query account transaction records | `crypto_account_records()` |
+| `getAccountBalance` | Query account balance | `crypto_account_balance()` |
+| `getAccountInfo` | Query account metadata | `crypto_account_info()` |
+| `getTransactionReceipts` | Get receipts by transaction ID | `crypto_transaction_receipts()` |
+| `getTransactionRecord` | Get a single transaction record | `crypto_transaction_record()` |
+| `getTransactionRecords` | Get paged transaction records | `crypto_transaction_records()` |
+| `getAccountDetails` | Rich account metadata (HIP-623) | `crypto_account_details()` |
+| Deprecated live hash RPCs | Exposed for completeness but throw `NOT_SUPPORTED` | `crypto_livehash_*()` (internal stubs) |
+
+### Consensus Service (`ConsensusService`)
+
+| RPC | Description | Planned Hadeda function |
+| --- | --- | --- |
+| `submitMessage` | Submit a topic message | `consensus_submit_message()` |
+| `submitMessageChunk` | Submit chunked message segments | `consensus_submit_message_chunk()` |
+| `getTopicInfo` | Query topic metadata | `consensus_topic_info()` |
+
+Hadeda will also surface the Mirror Consensus Service streaming subscription via
+`consensus_topic_subscribe()` to maintain parity with SDK streaming APIs.
+
+### File Service (`FileService`)
+
+| RPC | Description | Planned Hadeda function |
+| --- | --- | --- |
+| `createFile` | Create a new file | `file_create()` |
+| `updateFile` | Update file contents or keys | `file_update()` |
+| `deleteFile` | Delete a file | `file_delete()` |
+| `appendContent` | Append contents to a file | `file_append()` |
+| `getFileContent` | Download file contents | `file_content()` |
+| `getFileInfo` | Retrieve file metadata | `file_info()` |
+
+### Smart Contract Service (`SmartContractService`)
+
+| RPC | Description | Planned Hadeda function |
+| --- | --- | --- |
+| `createContract` | Deploy a smart contract | `contract_create()` |
+| `updateContract` | Update contract properties | `contract_update()` |
+| `contractCallMethod` | Execute a contract call | `contract_call()` |
+| `contractCallLocalMethod` | Local query (no state change) | `contract_call_local()` |
+| `deleteContract` | Delete a contract | `contract_delete()` |
+| `getContractInfo` | Query contract metadata | `contract_info()` |
+| `getContractRecords` | Fetch contract transaction records | `contract_records()` |
+| `getTxRecordByContractID` | Fetch records by contract ID | `contract_tx_record_by_id()` |
+
+### Token Service (`TokenService`)
+
+| RPC | Description | Planned Hadeda function |
+| --- | --- | --- |
+| `createToken` | Create fungible/NFT tokens | `token_create()` |
+| `updateToken` | Update token properties | `token_update()` |
+| `mintToken` | Mint new token units/NFTs | `token_mint()` |
+| `burnToken` | Burn token units/NFTs | `token_burn()` |
+| `deleteToken` | Delete a token | `token_delete()` |
+| `wipeTokenAccount` | Wipe an account's token balance | `token_wipe_account()` |
+| `freezeTokenAccount` | Freeze token for an account | `token_freeze_account()` |
+| `unfreezeTokenAccount` | Unfreeze token for an account | `token_unfreeze_account()` |
+| `grantKycToTokenAccount` | Grant KYC | `token_grant_kyc()` |
+| `revokeKycFromTokenAccount` | Revoke KYC | `token_revoke_kyc()` |
+| `associateTokens` | Associate fungible tokens | `token_associate()` |
+| `dissociateTokens` | Dissociate fungible tokens | `token_dissociate()` |
+| `approveTokenAllowance` | Approve token allowance | `token_approve_allowance()` |
+| `deleteTokenAllowance` | Revoke token allowance | `token_delete_allowance()` |
+| `getTokenInfo` | Query token metadata | `token_info()` |
+| `getTokenNftInfo` | Query NFT metadata | `token_nft_info()` |
+| `getTokenNftInfos` | List NFTs | `token_nft_infos()` |
+| `getAccountNftInfos` | List NFTs owned by an account | `token_account_nft_infos()` |
+| `getTokenNftTransferHistory` | NFT transfer history | `token_nft_transfer_history()` |
+| `getTokenRelationships` | Query account-token relationships | `token_relationships()` |
+
+### Schedule Service (`ScheduleService`)
+
+| RPC | Description | Planned Hadeda function |
+| --- | --- | --- |
+| `createSchedule` | Create a scheduled transaction | `schedule_create()` |
+| `deleteSchedule` | Delete a schedule | `schedule_delete()` |
+| `getScheduleInfo` | Query schedule metadata | `schedule_info()` |
+| `signSchedule` | Add signature to a schedule | `schedule_sign()` |
+
+### Network, Util, and Freeze services
+
+| Service | RPC | Planned function |
+| --- | --- | --- |
+| `NetworkService` | `getVersionInfo` | `network_version_info()` |
+| `NetworkService` | `getExecutionTime` | `network_execution_time()` |
+| `NetworkService` | `getAccountDetails` (HIP-623) | `network_account_details()` |
+| `FreezeService` | `freeze` | `freeze_network()` |
+| `FreezeService` | `freezeUpgrade` | `freeze_upgrade()` |
+| `FreezeService` | `freezeAbort` | `freeze_abort()` |
+| `UtilService` | `prng` | `util_prng()` |
+
+## SDK parity checklist
+
+* ✅ Mirror Node REST endpoint coverage documented above.
+* ✅ gRPC RPC coverage mapped to Hadeda function names.
+* ✅ Streaming utilities (Mirror topic subscribe, SDK helper parity) captured for
+  follow-up implementation.
+
+This checklist will be revisited at the end of Phase 1 to ensure any new Hedera
+API releases are incorporated before implementation begins.

--- a/workplan.md
+++ b/workplan.md
@@ -2,7 +2,7 @@
 
 ## Phase 1 – Foundations
 
-1. **Landscape analysis**
+1. ✅ **Landscape analysis**
    * Review Hedera SDKs (Go, Java, JavaScript) and protobuf definitions to catalog available operations.
    * Confirm REST endpoint behavior via Mirror Node API documentation and sample responses.
 2. **Package scaffolding**


### PR DESCRIPTION
## Summary
- add a landscape analysis document mapping Mirror Node REST endpoints and gRPC RPCs to planned Hadeda functions
- expand the README with a summarized endpoint coverage overview and streaming helper notes
- mark Phase 1, Step 1 of the workplan as complete with a green checkmark

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68d3b0419c288323b02d234ec1e49ba3