### PR TITLE
Quote next field names in test fixtures

### DIFF
--- a/tests/testthat/test-accounts.R
+++ b/tests/testthat/test-accounts.R
@@ -9,7 +9,7 @@ test_that("accounts_list paginates and parses records", {
         key = list(key = "302a300506032b6570032100abc")
       )
     ),
-    links = list(next = "accounts?cursor=next")
+    links = list("next" = "accounts?cursor=next")
   )
   page_two <- list(
     accounts = list(
@@ -20,7 +20,7 @@ test_that("accounts_list paginates and parses records", {
         key = list(key = "302a300506032b6570032100def")
       )
     ),
-    links = list(next = NULL)
+    links = list("next" = NULL)
   )
 
   with_mocked_bindings({

--- a/tests/testthat/test-hadeda-rest-paginate.R
+++ b/tests/testthat/test-hadeda-rest-paginate.R
@@ -2,8 +2,8 @@ test_that("hadeda_rest_paginate follows relative next links", {
   cfg <- hadeda_config(network = "testnet")
 
   responses <- list(
-    list(links = list(next = "accounts?cursor=abc")),
-    list(links = list(next = NULL))
+    list(links = list("next" = "accounts?cursor=abc")),
+    list(links = list("next" = NULL))
   )
 
   calls <- list()
@@ -28,8 +28,8 @@ test_that("hadeda_rest_paginate trims base path prefixes", {
   cfg <- hadeda_config(network = "testnet")
 
   responses <- list(
-    list(links = list(next = "/api/v1/accounts?cursor=def")),
-    list(links = list(next = NULL))
+    list(links = list("next" = "/api/v1/accounts?cursor=def")),
+    list(links = list("next" = NULL))
   )
 
   calls <- list()
@@ -52,8 +52,8 @@ test_that("hadeda_rest_paginate preserves path when next link is query only", {
   cfg <- hadeda_config(network = "testnet")
 
   responses <- list(
-    list(links = list(next = "?cursor=ghi")),
-    list(links = list(next = NULL))
+    list(links = list("next" = "?cursor=ghi")),
+    list(links = list("next" = NULL))
   )
 
   calls <- list()

--- a/tests/testthat/test-tokens-contracts.R
+++ b/tests/testthat/test-tokens-contracts.R
@@ -33,7 +33,7 @@ test_that("tokens_balances returns flattened balances", {
     expect_equal(query$limit, 2)
     expect_equal(query$`account.id`, "0.0.1001")
     expect_equal(query$order, "asc")
-    list(list(balances = balances, links = list(next = NULL)))
+    list(list(balances = balances, links = list("next" = NULL)))
   })
 
   expect_equal(nrow(tbl), 2)

--- a/tests/testthat/test-transactions.R
+++ b/tests/testthat/test-transactions.R
@@ -18,7 +18,7 @@ test_that("transactions_list honours filters and parses payload", {
           charged_tx_fee = 234
         )
       ),
-      links = list(next = NULL)
+      links = list("next" = NULL)
     )
   )
 
@@ -82,7 +82,7 @@ test_that("topics_messages returns parsed tibble", {
           sequence_number = 1
         )
       ),
-      links = list(next = "topics/0.0.2000/messages?sequencenumber=gt:1")
+      links = list("next" = "topics/0.0.2000/messages?sequencenumber=gt:1")
     ),
     list(
       messages = list(
@@ -94,7 +94,7 @@ test_that("topics_messages returns parsed tibble", {
           sequence_number = 2
         )
       ),
-      links = list(next = NULL)
+      links = list("next" = NULL)
     )
   )
 


### PR DESCRIPTION
## Summary
- quote the `next` field in test fixtures to avoid using the reserved word as a bare symbol

## Testing
- R -q -e "devtools::test()" *(fails: there is no package called 'devtools')*

------
https://chatgpt.com/codex/tasks/task_b_68d4dcd7abd08323a5b1dc26b6664ba8