### PR TITLE
Load package when running tests directly

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,7 @@
+if (!"package:hadeda" %in% search()) {
+  if (requireNamespace("pkgload", quietly = TRUE)) {
+    pkgload::load_all(path = "../..", quiet = TRUE)
+  } else {
+    stop("pkgload package is required to run these tests.")
+  }
+}


### PR DESCRIPTION
## Summary
- ensure the hadeda package is loaded when running the testthat suite directly

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: testthat not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d4e9a5212c83239840d19967b0a70f