### PR TITLE
Fix pagination path handling

### DIFF
--- a/R/hadeda_rest_paginate.R
+++ b/R/hadeda_rest_paginate.R
@@ -16,8 +16,18 @@
 #'
 #' @keywords internal
 hadeda_rest_paginate <- function(config, path, query = list()) {
+  split_path_segments <- function(path) {
+    if (is.null(path) || length(path) == 0) {
+      return(character())
+    }
+
+    path <- path[[1]]
+    segments <- strsplit(path, "/", fixed = TRUE)[[1]]
+    segments[segments != ""]
+  }
+
   rest <- hadeda_require_rest(config)
-  base_segments <- httr2::url_parse(rest$base_url)$path %||% character()
+  base_segments <- split_path_segments(httr2::url_parse(rest$base_url)$path)
 
   responses <- list()
   next_path <- path
@@ -42,7 +52,7 @@ hadeda_rest_paginate <- function(config, path, query = list()) {
       relative <- sub("^/+", "", next_link)
       pieces <- httr2::url_parse(paste0("https://placeholder.invalid/", relative))
 
-      path_segments <- pieces$path %||% character()
+      path_segments <- split_path_segments(pieces$path)
       if (length(base_segments) > 0 &&
           length(path_segments) >= length(base_segments) &&
           identical(path_segments[seq_along(base_segments)], base_segments)) {


### PR DESCRIPTION
## Summary
- normalize parsed REST paths by splitting into segments before trimming base prefixes
- ensure query-only pagination links reuse the current path

## Testing
- `R -q -e 'testthat::test_local()'` *(fails: Error in loadNamespace(x) : there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_b_68d4f1d5d9a0832397109e7626244cfc