### PR TITLE
Fix topic parsing and document endpoint coverage

### DIFF
--- a/R/topics_create.R
+++ b/R/topics_create.R
@@ -34,7 +34,7 @@ topics_create <- function(config,
   ))
 
   resp <- hadeda_rest_post(config, "topics", body)
-  record <- resp$topic %||% resp
+  record <- resp[["topic"]] %||% resp
   parsed <- hadeda_parse_topics(list(record))
 
   status <- resp$status %||% resp$receipt$status %||% NA_character_

--- a/R/topics_get.R
+++ b/R/topics_get.R
@@ -22,6 +22,21 @@ topics_get <- function(config,
   }
 
   resp <- hadeda_rest_get(config, paste0("topics/", topic_id))
-  record <- resp$topic %||% resp
+  record <- resp[["topic"]] %||% resp
+
+  if (is.null(record) || length(record) == 0) {
+    return(hadeda_parse_topics(list()))
+  }
+
+  while (
+    is.list(record) &&
+      length(record) == 1 &&
+      is.list(record[[1]]) &&
+      !rlang::has_name(record, "topic_id") &&
+      !rlang::has_name(record, "topicId")
+  ) {
+    record <- record[[1]]
+  }
+
   hadeda_parse_topics(list(record))
 }

--- a/R/topics_update.R
+++ b/R/topics_update.R
@@ -39,7 +39,7 @@ topics_update <- function(config,
   }
 
   resp <- hadeda_rest_post(config, paste0("topics/", topic_id), body)
-  record <- resp$topic %||% resp
+  record <- resp[["topic"]] %||% resp
   parsed <- hadeda_parse_topics(list(record))
 
   status <- resp$status %||% resp$receipt$status %||% NA_character_

--- a/docs/landscape-analysis.md
+++ b/docs/landscape-analysis.md
@@ -9,6 +9,11 @@ All planned Hadeda verbs share the signature conventions described in the README
 Each entry below references the upstream capability and the corresponding
 Hadeda function we will implement.
 
+## Coverage snapshot
+
+- **Mirror Node REST:** 16 of 38 documented endpoints now have corresponding Hadeda helpers (≈42% coverage), spanning accounts, blocks, contracts, network metadata, tokens, topics, and transactions.
+- **gRPC services:** Implementation work has not yet started; all RPCs below remain planned stubs.
+
 ## Mirror Node REST endpoints
 
 The Mirror Node API is documented at <https://docs.hedera.com/hedera/mirror-node-api>.
@@ -17,43 +22,46 @@ them to Hadeda functions. When a Mirror Node endpoint corresponds to a gRPC
 query, Hadeda will still provide an HTTP implementation because REST is the most
 widely available transport today.
 
-| Domain | Endpoint | Purpose | Planned Hadeda function |
-| --- | --- | --- | --- |
-| Accounts | `/api/v1/accounts` | List accounts with optional filtering, pagination, and staking metadata | `accounts_list()` |
-| Accounts | `/api/v1/accounts/{accountId}` | Retrieve a single account, including key, memo, staking info | `accounts_get()` |
-| Accounts | `/api/v1/accounts/{accountId}/balance` | Fetch the latest balance snapshot for an account | `accounts_balance()` |
-| Accounts | `/api/v1/accounts/{accountId}/allowances/crypto` | View approved HBAR allowances | `accounts_allowances_crypto()` |
-| Accounts | `/api/v1/accounts/{accountId}/allowances/tokens` | View approved fungible token allowances | `accounts_allowances_tokens()` |
-| Accounts | `/api/v1/accounts/{accountId}/allowances/nfts` | View approved NFT allowances | `accounts_allowances_nfts()` |
-| Accounts | `/api/v1/accounts/{accountId}/rewards` | Retrieve staking reward history | `accounts_rewards()` |
-| Accounts | `/api/v1/balances` | List account balances at a consensus timestamp | `balances_list()` |
-| Blocks | `/api/v1/blocks` | Enumerate blocks with hash, number, and timestamp | `blocks_list()` |
-| Blocks | `/api/v1/blocks/{blockNumberOrHash}` | Retrieve details for a specific block | `blocks_get()` |
-| Contracts | `/api/v1/contracts` | List smart contracts and metadata | `contracts_list()` |
-| Contracts | `/api/v1/contracts/{contractId}` | Fetch contract bytecode and attributes | `contracts_get()` |
-| Contracts | `/api/v1/contracts/{contractId}/results` | List execution results for a contract | `contracts_results()` |
-| Contracts | `/api/v1/contracts/results` | Query contract call results across contracts | `contracts_results_list()` |
-| Contracts | `/api/v1/contracts/results/{transactionId}` | Fetch a single contract execution result | `contracts_results_get()` |
-| Contracts | `/api/v1/contracts/{contractId}/state` | Get key-value state entries for a contract | `contracts_state()` |
-| Network | `/api/v1/network/exchangerate` | Retrieve current and next exchange rates | `network_exchange_rate()` |
-| Network | `/api/v1/network/fees` | Fetch fee schedules | `network_fees()` |
-| Network | `/api/v1/network/nodes` | List mirror and network nodes | `network_nodes()` |
-| Network | `/api/v1/network/supply` | Retrieve supply metrics (hbar total/circulating) | `network_supply()` |
-| Schedules | `/api/v1/schedules` | List scheduled transactions | `schedules_list()` |
-| Schedules | `/api/v1/schedules/{scheduleId}` | Get a scheduled transaction | `schedules_get()` |
-| State Proof | `/api/v1/stateproofs/{transactionId}` | Retrieve a transaction state proof | `stateproof_get()` |
-| Tokens | `/api/v1/tokens` | List tokens with filters | `tokens_list()` |
-| Tokens | `/api/v1/tokens/{tokenId}` | Retrieve token metadata | `tokens_get()` |
-| Tokens | `/api/v1/tokens/{tokenId}/balances` | List token balances by account | `tokens_balances()` |
-| Tokens | `/api/v1/tokens/{tokenId}/nfts` | Enumerate NFTs for a token | `tokens_nfts()` |
-| Tokens | `/api/v1/tokens/{tokenId}/nfts/{serialNumber}` | Fetch a single NFT | `tokens_nfts_get()` |
-| Tokens | `/api/v1/tokens/{tokenId}/nfts/{serialNumber}/transactions` | NFT transfer history | `tokens_nft_transactions()` |
-| Tokens | `/api/v1/tokens/{tokenId}/allowances` | Allowance list for a token | `tokens_allowances()` |
-| Topics | `/api/v1/topics/{topicId}/messages` | Stream topic messages | `topics_messages()` |
-| Transactions | `/api/v1/transactions` | List transactions with filters | `transactions_list()` |
-| Transactions | `/api/v1/transactions/{transactionId}` | Fetch transaction record and metadata | `transactions_get()` |
-| Transactions | `/api/v1/transactions/{transactionId}/stateproof` | Retrieve state proof for a transaction | `transactions_stateproof()` |
-| Transactions | `/api/v1/transactions/{transactionId}/record` | Retrieve detailed record | `transactions_record()` |
+| Domain | Endpoint | Purpose | Hadeda function | Status |
+| --- | --- | --- | --- | --- |
+| Accounts | `/api/v1/accounts` | List accounts with optional filtering, pagination, and staking metadata | `accounts_list()` | ✅ Implemented |
+| Accounts | `/api/v1/accounts/{accountId}` | Retrieve a single account, including key, memo, staking info | `accounts_get()` | ✅ Implemented |
+| Accounts | `/api/v1/accounts/{accountId}/balance` | Fetch the latest balance snapshot for an account | `accounts_balance()` | ✅ Implemented |
+| Accounts | `/api/v1/accounts/{accountId}/allowances/crypto` | View approved HBAR allowances | `accounts_allowances_crypto()` | 🚧 Planned |
+| Accounts | `/api/v1/accounts/{accountId}/allowances/tokens` | View approved fungible token allowances | `accounts_allowances_tokens()` | 🚧 Planned |
+| Accounts | `/api/v1/accounts/{accountId}/allowances/nfts` | View approved NFT allowances | `accounts_allowances_nfts()` | 🚧 Planned |
+| Accounts | `/api/v1/accounts/{accountId}/rewards` | Retrieve staking reward history | `accounts_rewards()` | 🚧 Planned |
+| Accounts | `/api/v1/balances` | List account balances at a consensus timestamp | `balances_list()` | 🚧 Planned |
+| Blocks | `/api/v1/blocks` | Enumerate blocks with hash, number, and timestamp | `blocks_list()` | ✅ Implemented |
+| Blocks | `/api/v1/blocks/{blockNumberOrHash}` | Retrieve details for a specific block | `blocks_get()` | ✅ Implemented |
+| Contracts | `/api/v1/contracts` | List smart contracts and metadata | `contracts_list()` | 🚧 Planned |
+| Contracts | `/api/v1/contracts/{contractId}` | Fetch contract metadata | `contracts_get()` | ✅ Implemented |
+| Contracts | `/api/v1/contracts/{contractId}/bytecode` | Retrieve smart contract bytecode | `contracts_bytecode()` | ✅ Implemented |
+| Contracts | `/api/v1/contracts/{contractId}/results` | List execution results for a contract | `contracts_results()` | 🚧 Planned |
+| Contracts | `/api/v1/contracts/results` | Query contract call results across contracts | `contracts_results_list()` | 🚧 Planned |
+| Contracts | `/api/v1/contracts/results/{transactionId}` | Fetch a single contract execution result | `contracts_results_get()` | 🚧 Planned |
+| Contracts | `/api/v1/contracts/{contractId}/state` | Get key-value state entries for a contract | `contracts_state()` | 🚧 Planned |
+| Network | `/api/v1/network/exchangerate` | Retrieve current and next exchange rates | `network_exchange_rate()` | 🚧 Planned |
+| Network | `/api/v1/network/fees` | Fetch fee schedules | `network_fees()` | 🚧 Planned |
+| Network | `/api/v1/network/nodes` | List mirror and network nodes | `network_nodes()` | ✅ Implemented |
+| Network | `/api/v1/network/stake` | Retrieve network stake metadata | `network_stake()` | ✅ Implemented |
+| Network | `/api/v1/network/supply` | Retrieve supply metrics (hbar total/circulating) | `network_supply()` | 🚧 Planned |
+| Schedules | `/api/v1/schedules` | List scheduled transactions | `schedules_list()` | 🚧 Planned |
+| Schedules | `/api/v1/schedules/{scheduleId}` | Get a scheduled transaction | `schedules_get()` | 🚧 Planned |
+| State Proof | `/api/v1/stateproofs/{transactionId}` | Retrieve a transaction state proof | `stateproof_get()` | 🚧 Planned |
+| Tokens | `/api/v1/tokens` | List tokens with filters | `tokens_list()` | 🚧 Planned |
+| Tokens | `/api/v1/tokens/{tokenId}` | Retrieve token metadata | `tokens_get()` | ✅ Implemented |
+| Tokens | `/api/v1/tokens/{tokenId}/balances` | List token balances by account | `tokens_balances()` | ✅ Implemented |
+| Tokens | `/api/v1/tokens/{tokenId}/nfts` | Enumerate NFTs for a token | `tokens_nfts()` | ✅ Implemented |
+| Tokens | `/api/v1/tokens/{tokenId}/nfts/{serialNumber}` | Fetch a single NFT | `tokens_nfts_get()` | 🚧 Planned |
+| Tokens | `/api/v1/tokens/{tokenId}/nfts/{serialNumber}/transactions` | NFT transfer history | `tokens_nft_transactions()` | 🚧 Planned |
+| Tokens | `/api/v1/tokens/{tokenId}/allowances` | Allowance list for a token | `tokens_allowances()` | 🚧 Planned |
+| Topics | `/api/v1/topics/{topicId}` | Retrieve topic metadata | `topics_get()` | ✅ Implemented |
+| Topics | `/api/v1/topics/{topicId}/messages` | Stream topic messages | `topics_messages()` | ✅ Implemented |
+| Transactions | `/api/v1/transactions` | List transactions with filters | `transactions_list()` | ✅ Implemented |
+| Transactions | `/api/v1/transactions/{transactionId}` | Fetch transaction record and metadata | `transactions_get()` | ✅ Implemented |
+| Transactions | `/api/v1/transactions/{transactionId}/stateproof` | Retrieve state proof for a transaction | `transactions_stateproof()` | 🚧 Planned |
+| Transactions | `/api/v1/transactions/{transactionId}/record` | Retrieve detailed record | `transactions_record()` | 🚧 Planned |
 
 Additional REST helpers planned for parity with official SDK utilities:
 
@@ -67,8 +75,10 @@ Additional REST helpers planned for parity with official SDK utilities:
 
 The official SDKs expose the Hedera gRPC services defined in
 `hedera-protobufs`. Hadeda will mirror these operations with tidyverse-friendly
-functions. Each RPC below will correspond to a Hadeda verb accepting a `.client`
-configured with signing keys and channel information.
+functions. Implementation has not begun yet; the table below tracks the planned
+surface so we can mark progress as gRPC helpers land. Each RPC will correspond to
+a Hadeda verb accepting a `.client` configured with signing keys and channel
+information.
 
 ### Crypto Service (`CryptoService`)
 

--- a/tests/testthat/test-topics.R
+++ b/tests/testthat/test-topics.R
@@ -74,6 +74,31 @@ test_that("topics_get retrieves topic metadata", {
   expect_equal(tbl$auto_renew_account, "0.0.3")
 })
 
+test_that("topics_get flattens nested topic envelopes", {
+  cfg <- hadeda_config(network = "testnet")
+  topic_id <- "0.0.2000"
+  response <- list(
+    topic = list(
+      list(
+        topicId = topic_id,
+        memo = "demo",
+        autoRenewAccount = "0.0.3"
+      )
+    )
+  )
+
+  with_mocked_bindings({
+    tbl <- topics_get(cfg, topic_id)
+  }, hadeda_rest_get = function(config, path, query = list()) {
+    expect_identical(path, paste0("topics/", topic_id))
+    response
+  })
+
+  expect_equal(tbl$topic_id, topic_id)
+  expect_equal(tbl$memo, "demo")
+  expect_equal(tbl$auto_renew_account, "0.0.3")
+})
+
 test_that("topics_create submits payload", {
   cfg <- hadeda_config(network = "testnet")
   record <- list(


### PR DESCRIPTION
## Summary
- prevent partial matching when extracting topic records so REST helpers parse metadata correctly
- extend topic tests to cover nested topic envelopes and ensure metadata assertions
- refresh the landscape analysis with a coverage snapshot and per-endpoint implementation status

## Testing
- Rscript -e 'testthat::test_local()'

------
https://chatgpt.com/codex/tasks/task_b_68d4fc06b4dc8323b55f296f7003964f