### PR TITLE
Improve unsupported transport messaging

### DIFF
--- a/R/hadeda_choose_transport.R
+++ b/R/hadeda_choose_transport.R
@@ -35,14 +35,14 @@ hadeda_choose_transport <- function(config, .transport = NULL,
 
   if (choice == "rest" && !rest_supported) {
     cli::cli_abort(
-      "REST transport is not supported for this helper.",
+      "REST transport is not supported for this helper. Please select the gRPC transport.",
       class = "hadeda_unsupported_transport",
       call = caller
     )
   }
   if (choice == "grpc" && !grpc_supported) {
     cli::cli_abort(
-      "gRPC transport is not supported for this helper.",
+      "gRPC transport is not supported for this helper. Please select the REST transport.",
       class = "hadeda_unsupported_transport",
       call = caller
     )


### PR DESCRIPTION
## Summary
- clarify unsupported transport errors to recommend the appropriate alternative transport

## Testing
- `R -q -e 'testthat::test_local()'` *(fails: missing testthat package in container)*
- `R -q -e 'renv::restore(prompt = FALSE)'` *(fails: missing renv package in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d51b4e0090832389ad6f7087aa3fea