### PR TITLE
Improve transport error messaging

### DIFF
--- a/R/hadeda_choose_transport.R
+++ b/R/hadeda_choose_transport.R
@@ -35,14 +35,14 @@ hadeda_choose_transport <- function(config, .transport = NULL,
 
   if (choice == "rest" && !rest_supported) {
     cli::cli_abort(
-      "REST transport is not supported for this helper. Please select the gRPC transport.",
+      "This helper requires the gRPC transport; the REST transport is not supported.",
       class = "hadeda_unsupported_transport",
       call = caller
     )
   }
   if (choice == "grpc" && !grpc_supported) {
     cli::cli_abort(
-      "gRPC transport is not supported for this helper. Please select the REST transport.",
+      "This helper requires the REST transport; the gRPC transport is not supported.",
       class = "hadeda_unsupported_transport",
       call = caller
     )


### PR DESCRIPTION
## Summary
- clarify error messaging when a helper requires gRPC by explicitly stating the gRPC transport is required
- clarify messaging for helpers that require the REST transport

## Testing
- `Rscript -e 'testthat::test_local()'` *(fails: testthat package unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d51ef41f608323934cb11f89bacec5