### PR TITLE
Align crypto transaction helpers with latest Hedera protos

### DIFF
--- a/R/crypto_account_balance.R
+++ b/R/crypto_account_balance.R
@@ -38,7 +38,9 @@ crypto_account_balance <- function(config,
 #' @keywords internal
 hadeda_grpc_crypto_account_balance <- function(config, account_id) {
   grpc <- hadeda_require_grpc(config)
-  handler <- grpc$get_account_balance %||% grpc$crypto_get_account_balance %||% grpc$account_balance
+  handler <- grpc$crypto_get_balance %||% grpc$cryptoGetBalance %||%
+    grpc$get_account_balance %||% grpc$getAccountBalance %||%
+    grpc$crypto_get_account_balance %||% grpc$account_balance
   if (!rlang::is_function(handler)) {
     cli::cli_abort(
       "No gRPC CryptoService balance handler configured.\nProvide `config$grpc$get_account_balance` to enable balance queries.",

--- a/R/crypto_account_info.R
+++ b/R/crypto_account_info.R
@@ -36,7 +36,8 @@ crypto_account_info <- function(config,
 #' @keywords internal
 hadeda_grpc_crypto_account_info <- function(config, account_id) {
   grpc <- hadeda_require_grpc(config)
-  handler <- grpc$get_account_info %||% grpc$crypto_get_account_info %||% grpc$account_info
+  handler <- grpc$get_account_info %||% grpc$getAccountInfo %||%
+    grpc$crypto_get_account_info %||% grpc$account_info
   if (!rlang::is_function(handler)) {
     cli::cli_abort(
       "No gRPC CryptoService account info handler configured.\nProvide `config$grpc$get_account_info` to enable info queries.",
@@ -87,7 +88,8 @@ crypto_account_details <- function(config,
 #' @keywords internal
 hadeda_grpc_crypto_account_details <- function(config, account_id) {
   grpc <- hadeda_require_grpc(config)
-  handler <- grpc$get_account_details %||% grpc$crypto_get_account_details
+  handler <- grpc$get_account_details %||% grpc$getAccountDetails %||%
+    grpc$crypto_get_account_details
   if (!rlang::is_function(handler)) {
     cli::cli_abort(
       "No gRPC CryptoService account details handler configured.\nProvide `config$grpc$get_account_details` to enable details queries.",

--- a/R/crypto_account_records.R
+++ b/R/crypto_account_records.R
@@ -37,7 +37,8 @@ crypto_account_records <- function(config,
 #' @keywords internal
 hadeda_grpc_crypto_account_records <- function(config, account_id) {
   grpc <- hadeda_require_grpc(config)
-  handler <- grpc$get_account_records %||% grpc$crypto_get_account_records %||% grpc$account_records
+  handler <- grpc$get_account_records %||% grpc$getAccountRecords %||%
+    grpc$crypto_get_account_records %||% grpc$account_records
   if (!rlang::is_function(handler)) {
     cli::cli_abort(
       "No gRPC CryptoService account records handler configured.\nProvide `config$grpc$get_account_records` to enable record queries.",

--- a/R/crypto_transaction_queries.R
+++ b/R/crypto_transaction_queries.R
@@ -38,7 +38,8 @@ crypto_transaction_receipts <- function(config,
 #' @keywords internal
 hadeda_grpc_crypto_transaction_receipts <- function(config, transaction_id) {
   grpc <- hadeda_require_grpc(config)
-  handler <- grpc$get_transaction_receipts %||% grpc$crypto_get_transaction_receipts %||% grpc$transaction_receipts
+  handler <- grpc$get_transaction_receipts %||% grpc$getTransactionReceipts %||%
+    grpc$crypto_get_transaction_receipts %||% grpc$transaction_receipts
   if (!rlang::is_function(handler)) {
     cli::cli_abort(
       "No gRPC CryptoService transaction receipt handler configured.\nProvide `config$grpc$get_transaction_receipts` to enable receipt queries.",
@@ -54,16 +55,22 @@ hadeda_grpc_crypto_transaction_receipts <- function(config, transaction_id) {
 
 #' Retrieve a single transaction record
 #'
-#' Invoke `getTransactionRecord` to fetch the full transaction record for a
-#' transaction identifier.
+#' Invoke the CryptoService `getTxRecordByTxID` query to fetch the full
+#' transaction record for a transaction identifier.
 #'
 #' @inheritParams crypto_transaction_receipts
+#' @param include_duplicates Logical toggle requesting duplicate transaction
+#'   records for the identifier.
+#' @param include_child_records Logical toggle requesting child transaction
+#'   records spawned by the identifier.
 #'
 #' @return A tibble with a single transaction record.
 #'
 #' @export
 crypto_transaction_record <- function(config,
                                       transaction_id,
+                                      include_duplicates = FALSE,
+                                      include_child_records = FALSE,
                                       .transport = NULL) {
   transport <- hadeda_choose_transport(
     config,
@@ -81,41 +88,57 @@ crypto_transaction_record <- function(config,
 
   response <- hadeda_grpc_crypto_transaction_record(
     config = config,
-    transaction_id = transaction_id
+    transaction_id = transaction_id,
+    include_duplicates = include_duplicates,
+    include_child_records = include_child_records
   )
 
-  hadeda_parse_grpc_transaction_record(response)
+  hadeda_parse_grpc_transaction_record_response(response)
 }
 
 #' @keywords internal
-hadeda_grpc_crypto_transaction_record <- function(config, transaction_id) {
+hadeda_grpc_crypto_transaction_record <- function(config,
+                                                  transaction_id,
+                                                  include_duplicates = FALSE,
+                                                  include_child_records = FALSE) {
   grpc <- hadeda_require_grpc(config)
-  handler <- grpc$get_transaction_record %||% grpc$crypto_get_transaction_record %||% grpc$transaction_record
+  handler <- grpc$get_tx_record_by_tx_id %||% grpc$getTxRecordByTxID %||%
+    grpc$get_transaction_record %||% grpc$getTransactionRecord %||%
+    grpc$crypto_get_transaction_record %||% grpc$transaction_record
   if (!rlang::is_function(handler)) {
     cli::cli_abort(
-      "No gRPC CryptoService transaction record handler configured.\nProvide `config$grpc$get_transaction_record` to enable record queries.",
+      "No gRPC CryptoService transaction record handler configured.\nProvide `config$grpc$get_tx_record_by_tx_id` to enable record queries.",
       class = "hadeda_grpc_not_configured"
     )
   }
 
   handler(
     config = config,
-    transaction_id = transaction_id
+    transaction_id = transaction_id,
+    include_duplicates = include_duplicates,
+    include_child_records = include_child_records
   )
 }
 
 #' Retrieve transaction records for a transaction ID
 #'
-#' Invoke the `getTransactionRecords` RPC which may return multiple records for a
-#' single transaction identifier (for example child transactions).
-#'
+#' Request duplicate or child records for a transaction identifier. The helper
+#' returns one row per duplicate or child record along with the parsed receipt
+#' and transfer metadata.
+#' 
 #' @inheritParams crypto_transaction_receipts
-#'
+#' @param include_duplicates Logical toggle requesting duplicate transaction
+#'   records for the identifier. Defaults to `TRUE` for convenience.
+#' @param include_child_records Logical toggle requesting child transaction
+#'   records spawned by the identifier. Defaults to `TRUE`.
+#' 
 #' @return A tibble with one row per record.
-#'
+#' 
 #' @export
 crypto_transaction_records <- function(config,
                                        transaction_id,
+                                       include_duplicates = TRUE,
+                                       include_child_records = TRUE,
                                        .transport = NULL) {
   transport <- hadeda_choose_transport(
     config,
@@ -131,27 +154,16 @@ crypto_transaction_records <- function(config,
     cli::cli_abort("`transaction_id` is required when requesting transaction records.")
   }
 
-  response <- hadeda_grpc_crypto_transaction_records(
+  response <- hadeda_grpc_crypto_transaction_record(
     config = config,
-    transaction_id = transaction_id
+    transaction_id = transaction_id,
+    include_duplicates = include_duplicates,
+    include_child_records = include_child_records
   )
 
-  hadeda_parse_grpc_transaction_records(response)
-}
-
-#' @keywords internal
-hadeda_grpc_crypto_transaction_records <- function(config, transaction_id) {
-  grpc <- hadeda_require_grpc(config)
-  handler <- grpc$get_transaction_records %||% grpc$crypto_get_transaction_records
-  if (!rlang::is_function(handler)) {
-    cli::cli_abort(
-      "No gRPC CryptoService transaction records handler configured.\nProvide `config$grpc$get_transaction_records` to enable record queries.",
-      class = "hadeda_grpc_not_configured"
-    )
-  }
-
-  handler(
-    config = config,
-    transaction_id = transaction_id
+  hadeda_parse_grpc_transaction_record_sets(
+    response,
+    include_duplicates = include_duplicates,
+    include_child_records = include_child_records
   )
 }

--- a/README.md
+++ b/README.md
@@ -48,17 +48,21 @@ JavaScript SDKs has a corresponding Hadeda verb:
 
 * **CryptoService** – account lifecycle management, hbar/token transfers, and
   allowance administration (`crypto_create_account()`, `crypto_transfer()`,
-  `crypto_delete_allowances()`, etc.).
-* **ConsensusService** – topic message submission (chunked and single) and
-  topic metadata queries.
+  `crypto_delete_allowances()`, `crypto_transaction_record()` for
+  `getTxRecordByTxID`, etc.).
+* **ConsensusService** – topic creation, updates, deletions, message
+  submission (chunked and single), and topic metadata queries.
 * **FileService** – file creation, updates, appends, deletes, and metadata
   queries.
 * **SmartContractService** – contract deployment, updates, on-ledger and local
-  calls, deletions, and record retrieval.
+  calls, deletions, and record retrieval (including the deprecated
+  `getContractTxRecordByID`).
 * **TokenService** – token lifecycle operations, treasury interactions,
-  association helpers, and NFT-specific queries.
+  association helpers, NFT-specific queries, and the newer airdrop/pause APIs
+  slated for future Hadeda helpers.
 * **ScheduleService** – schedule creation, signing, deletion, and info queries.
-* **Network/Util/Freeze services** – network metadata, PRNG utility, and freeze
+* **Network/Util/Freeze services** – network metadata, PRNG utility (with
+  planned support for the new `atomicBatch` transaction), and freeze
   orchestration endpoints required for node operators.
 
 Additional streaming helpers such as `topics_messages_stream()` and
@@ -67,13 +71,14 @@ workflows remain on par with JavaScript SDK capabilities.
 
 The initial gRPC surface now spans the full CryptoService (`crypto_create_account()`,
 `crypto_update_account()`, `crypto_update_account_keys()`, `crypto_transfer()`,
-`crypto_delete()`, allowance helpers, and the various account/transaction
-queries), alongside TokenService helpers (`tokens_create()`, `tokens_associate()`,
-`tokens_transfer()`), SmartContractService deployment and execution utilities
-(`contract_deploy()`, `contract_call()`), and the REST-backed
-`consensus_submit_message()`. These functions accept tidy inputs, delegate to
-user-provided gRPC handlers, and return acknowledgement tibbles that mirror the
-rest of the package.
+`crypto_delete()`, allowance helpers, and the updated
+`crypto_transaction_record()` / `crypto_transaction_records()` pair that now
+surface duplicate and child records), alongside TokenService helpers
+(`tokens_create()`, `tokens_associate()`, `tokens_transfer()`),
+SmartContractService deployment and execution utilities (`contract_deploy()`,
+`contract_call()`), and the REST-backed `consensus_submit_message()`. These
+functions accept tidy inputs, delegate to user-provided gRPC handlers, and
+return acknowledgement tibbles that mirror the rest of the package.
 
 ## Naming and argument conventions
 

--- a/docs/landscape-analysis.md
+++ b/docs/landscape-analysis.md
@@ -93,18 +93,23 @@ gRPC helpers land. Each RPC corresponds to a Hadeda verb that consumes a
 | `approveAllowances` | Approve fungible/NFT allowances | `crypto_approve_allowances()` | ✅ Implemented |
 | `deleteAllowances` | Revoke allowances | `crypto_delete_allowances()` | ✅ Implemented |
 | `getAccountRecords` | Query account transaction records | `crypto_account_records()` | ✅ Implemented |
-| `getAccountBalance` | Query account balance | `crypto_account_balance()` | ✅ Implemented |
+| `cryptoGetBalance` | Query account balance | `crypto_account_balance()` | ✅ Implemented |
 | `getAccountInfo` | Query account metadata | `crypto_account_info()` | ✅ Implemented |
 | `getTransactionReceipts` | Get receipts by transaction ID | `crypto_transaction_receipts()` | ✅ Implemented |
-| `getTransactionRecord` | Get a single transaction record | `crypto_transaction_record()` | ✅ Implemented |
-| `getTransactionRecords` | Get paged transaction records | `crypto_transaction_records()` | ✅ Implemented |
-| `getAccountDetails` | Rich account metadata (HIP-623) | `crypto_account_details()` | ✅ Implemented |
+| `getTxRecordByTxID` | Get the primary, duplicate, and child records for a transaction | `crypto_transaction_record()` / `crypto_transaction_records()` | ✅ Implemented |
 | Deprecated live hash RPCs | Exposed for completeness but throw `NOT_SUPPORTED` | `crypto_livehash_*()` (internal stubs) | ✅ Implemented |
+
+`getTransactionRecords` was removed from the 2024 protobuf refresh. Hadeda now
+surfaces duplicate and child records exclusively through the updated
+`getTxRecordByTxID` helper pair above.
 
 ### Consensus Service (`ConsensusService`)
 
 | RPC | Description | Hadeda function | Status |
 | --- | --- | --- | --- |
+| `createTopic` | Create a new consensus topic | `consensus_create_topic()` | 🚧 Planned |
+| `updateTopic` | Update consensus topic metadata | `consensus_update_topic()` | 🚧 Planned |
+| `deleteTopic` | Delete a consensus topic | `consensus_delete_topic()` | 🚧 Planned |
 | `submitMessage` | Submit a topic message | `consensus_submit_message()` | ✅ Implemented |
 | `submitMessageChunk` | Submit chunked message segments | `consensus_submit_message_chunk()` | ✅ Implemented |
 | `getTopicInfo` | Query topic metadata | `consensus_topic_info()` | ✅ Implemented |
@@ -133,8 +138,11 @@ Hadeda will also surface the Mirror Consensus Service streaming subscription via
 | `contractCallLocalMethod` | Local query (no state change) | `contract_call_local()` | ✅ Implemented |
 | `deleteContract` | Delete a contract | `contract_delete()` | ✅ Implemented |
 | `getContractInfo` | Query contract metadata | `contract_info()` | ✅ Implemented |
-| `getContractRecords` | Fetch contract transaction records | `contract_records()` | ✅ Implemented |
+| `getContractRecords` | Fetch contract transaction records | `contract_records()` | ⚠️ Deprecated in proto |
 | `getTxRecordByContractID` | Fetch records by contract ID | `contract_tx_record_by_id()` | ✅ Implemented |
+
+The Hedera team marks `getContractRecords` as obsolete. The Hadeda helper now
+documents the limitation and will be retired once the upstream RPC is removed.
 
 ### Token Service (`TokenService`)
 
@@ -154,12 +162,20 @@ Hadeda will also surface the Mirror Consensus Service streaming subscription via
 | `dissociateTokens` | Dissociate fungible tokens | `tokens_dissociate()` | 🚧 Planned |
 | `approveTokenAllowance` | Approve token allowance | `tokens_approve_allowance()` | 🚧 Planned |
 | `deleteTokenAllowance` | Revoke token allowance | `tokens_delete_allowance()` | 🚧 Planned |
+| `updateTokenFeeSchedule` | Update custom fee schedule | `tokens_update_fee_schedule()` | 🚧 Planned |
 | `getTokenInfo` | Query token metadata | `tokens_info()` | 🚧 Planned |
 | `getTokenNftInfo` | Query NFT metadata | `tokens_nft_info()` | 🚧 Planned |
 | `getTokenNftInfos` | List NFTs | `tokens_nft_infos()` | 🚧 Planned |
 | `getAccountNftInfos` | List NFTs owned by an account | `tokens_account_nft_infos()` | 🚧 Planned |
 | `getTokenNftTransferHistory` | NFT transfer history | `tokens_nft_transfer_history()` | 🚧 Planned |
 | `getTokenRelationships` | Query account-token relationships | `tokens_relationships()` | 🚧 Planned |
+| `pauseToken` | Pause token transfers | `tokens_pause()` | 🚧 Planned |
+| `unpauseToken` | Resume token transfers | `tokens_unpause()` | 🚧 Planned |
+| `updateNfts` | Update NFT metadata for multiple serials | `tokens_update_nfts()` | 🚧 Planned |
+| `rejectToken` | Reject one or more tokens | `tokens_reject()` | 🚧 Planned |
+| `airdropTokens` | Airdrop tokens to accounts | `tokens_airdrop()` | 🚧 Planned |
+| `cancelAirdrop` | Cancel pending airdrops | `tokens_cancel_airdrop()` | 🚧 Planned |
+| `claimAirdrop` | Claim pending airdrops | `tokens_claim_airdrop()` | 🚧 Planned |
 
 ### Schedule Service (`ScheduleService`)
 
@@ -177,10 +193,12 @@ Hadeda will also surface the Mirror Consensus Service streaming subscription via
 | `NetworkService` | `getVersionInfo` | `network_version_info()` |
 | `NetworkService` | `getExecutionTime` | `network_execution_time()` |
 | `NetworkService` | `getAccountDetails` (HIP-623) | `network_account_details()` |
+| `NetworkService` | `uncheckedSubmit` (deprecated) | — |
 | `FreezeService` | `freeze` | `freeze_network()` |
 | `FreezeService` | `freezeUpgrade` | `freeze_upgrade()` |
 | `FreezeService` | `freezeAbort` | `freeze_abort()` |
 | `UtilService` | `prng` | `util_prng()` |
+| `UtilService` | `atomicBatch` | `util_atomic_batch()` |
 
 ## SDK parity checklist
 

--- a/vignettes/hadeda-transactions.Rmd
+++ b/vignettes/hadeda-transactions.Rmd
@@ -52,6 +52,22 @@ detail <- transactions_get(
 detail |> tidyr::unnest(records)
 ```
 
+When you need authoritative receipts straight from the node, switch to the gRPC
+helpers. `crypto_transaction_record()` now wraps the `getTxRecordByTxID` query
+and can request duplicate or child records in a single call:
+
+```{r}
+record <- crypto_transaction_record(
+  hadeda_config(network = "testnet"),
+  transaction_id = "0.0.5005-1700000000-000000000",
+  include_duplicates = TRUE,
+  include_child_records = TRUE
+)
+
+record$duplicate_records[[1]]
+record$child_records[[1]]
+```
+
 ## Submit new transfers
 
 For live transfers you will configure gRPC handlers to sign and submit

--- a/workplan.md
+++ b/workplan.md
@@ -34,12 +34,21 @@
 
 7. ✅ **Consensus service**
    * Implement `consensus_submit_message()` with message chunking and acknowledgement handling.
+   * Add gRPC helpers for `createTopic`, `updateTopic`, and `deleteTopic` now
+     that the protobuf bundle documents their requirements.
 8. ✅ **Crypto service**
    * Implement account creation, key management, and transfer helpers, leveraging protobuf builders. Account creation relies solely on gRPC handlers because mirror endpoints remain read-only.
 9. ✅ **Token service**
    * Implement token creation, association, and transfer RPC helpers with explicit fee controls and REST fallbacks when possible.
+   * Track the 2024 protobuf additions (`updateTokenFeeSchedule`, pause/unpause,
+     NFT metadata updates, airdrop lifecycle) and schedule follow-up helpers to
+     reach parity.
 10. ✅ **Smart contract service**
     * Provide `contract_call()`, deployment utilities, and management/query helpers covering the SmartContractService RPC surface, including contract parameter encoding.
+    * Document that `getContractRecords` remains deprecated upstream and should
+      be replaced by more targeted queries when possible.
+    * Scope a UtilService `atomicBatch()` helper for orchestrating grouped
+      submissions alongside contract workflows.
 
 ## Phase 4 – Quality & documentation
 


### PR DESCRIPTION
## Summary
- update the crypto transaction record helpers to call `getTxRecordByTxID`, expose duplicate/child records, and refresh parsing logic
- broaden gRPC handler fallbacks so balance, info, and record helpers recognise the method names shipped in the latest protobuf bundle
- refresh the README, landscape analysis, workplan, and vignette notes to reflect the 2024 Hedera proto changes and planned coverage

## Testing
- devtools::test(filter = "crypto")


------
https://chatgpt.com/codex/tasks/task_b_68d638ab274c83238ee94a394a8309c8